### PR TITLE
Add -DRIVERHOST and -SUBHOST support for distributed Schrödinger jobs

### DIFF
--- a/maize/steps/mai/common/schrodinger.py
+++ b/maize/steps/mai/common/schrodinger.py
@@ -158,6 +158,20 @@ class Schrodinger(Node, register=False):
     host: Parameter[str] = Parameter(default="localhost")
     """Host to use for job submission"""
 
+    driverhost: Parameter[str] = Parameter(optional=True)
+    """Host for the driver/coordinator process of distributed jobs.
+    Overrides ``-HOST`` for the driver only, allowing the lightweight
+    coordinator to run on a dedicated partition while subjobs use
+    compute hosts specified by ``host`` (or ``subhost``).
+    Only relevant when ``n_jobs > 1``. See the Schrodinger documentation
+    section 'The HOST, DRIVERHOST, and SUBHOST Options' for details."""
+
+    subhost: Parameter[str] = Parameter(optional=True)
+    """Host(s) for subjobs of distributed jobs. Overrides ``-HOST``
+    for subjobs only. When set, ``-HOST`` specifies only the driver
+    location. See the Schrodinger documentation section 'Running
+    Distributed Schrodinger Jobs' for details."""
+
     fallback: Flag = Flag(default=False)
     """If the host is not compatible, will fallback to 'localhost'"""
 
@@ -356,7 +370,7 @@ class Schrodinger(Node, register=False):
         # will be correctly setup all subsequent attempts
         if _n_failures == 0:
             # Cleanup command from previously specified values
-            for token in ("-JOBNAME", "-HOST", "-NJOBS"):
+            for token in ("-JOBNAME", "-HOST", "-NJOBS", "-DRIVERHOST", "-SUBHOST"):
                 if token in command:
                     idx = command.index(token)
                     command.pop(idx + 1)
@@ -372,6 +386,16 @@ class Schrodinger(Node, register=False):
                 host = f"{host}:{self.n_jobs.value}"
             command.extend(["-HOST", host])
             command.extend(["-NJOBS", str(self.n_jobs.value)])
+
+            # For distributed jobs (n_jobs > 1), allow separate routing of the
+            # driver/coordinator process and subjobs. This follows Schrodinger's
+            # Job Control conventions: -DRIVERHOST overrides -HOST for the driver,
+            # -SUBHOST overrides -HOST for subjobs. When neither is set, all
+            # processes use the -HOST value (existing behavior).
+            if self.driverhost.is_set:
+                command.extend(["-DRIVERHOST", self.driverhost.value])
+            if self.subhost.is_set:
+                command.extend(["-SUBHOST", self.subhost.value])
 
             # Add the actual args at the end to maintain correct ordering
             if isinstance(args, str):


### PR DESCRIPTION
BODY:

## Summary

Adds optional `driverhost` and `subhost` parameters to the `Schrodinger` base class in `maize/steps/mai/common/schrodinger.py`, enabling separate host routing for the driver/coordinator process and compute-intensive subjobs in distributed Schrödinger jobs.

Resolves #13.

## Motivation

Schrödinger's Job Control supports three host-routing flags for distributed jobs (Glide with `-NJOBS > 1`, FEP+, IFD, etc.):

- `-HOST` — sets both driver and subjob hosts (current maize behavior)
- `-DRIVERHOST` — overrides for the lightweight coordinator/driver process
- `-SUBHOST` — overrides for compute-intensive subjobs

On HPC clusters with dedicated driver partitions (a standard Schrödinger deployment pattern — their sample `hosts.yml` ships a `driver` entry), the driver process wastes a full compute slot when only `-HOST` is available. This matters on small partitions where every slot counts.

## Changes

- **2 new optional parameters** on `Schrodinger` class: `driverhost` and `subhost` (with docstrings referencing the Schrödinger docs)
- **Token cleanup loop**: extended to strip `-DRIVERHOST` and `-SUBHOST` alongside `-JOBNAME`, `-HOST`, `-NJOBS`
- **Command construction**: after `-NJOBS` injection, conditionally emits `-DRIVERHOST` and/or `-SUBHOST` when the parameters are set

## Backward Compatibility

When `driverhost` and `subhost` are not set (the default), the command construction is identical to the current code. No existing workflows are affected.

## Testing

Validated on an AWS ParallelCluster (pcluster 3.11.1, Ubuntu 22.04) running Schrödinger Suite 2025-4 with REINVENT4 and Maize 0.9.4:

- End-to-end Maize → LigPrep → Glide (HTVS, `n_jobs=4`) pipeline confirmed working with `-HOST` routing to a remote Job Server
- Distributed Glide correctly spawns driver + 4 worker subjobs via the Job Server's Slurm queue integration
- Patch applied to production environment alongside existing maize patches (remote jobserver, retry logic, timeout adjustments)

## Schrödinger Documentation Reference

- "The HOST, DRIVERHOST, and SUBHOST Options" (`jobs/running_jobs_command_line_host_options.htm`, 2025-4)
- "Running Distributed Schrödinger Jobs" (`jobs/distributed_jobs.htm`, 2025-4) — Table 1 confirms Glide and LigPrep use "Standard" driver location